### PR TITLE
Add last updated information

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,16 @@ To add a graph post:
     - `perview_image` is an optional image that will be shown on post previews. ideally a 2-by-1 or 3-by-1 image with a width of 1200px. It is recommended to add for SEO.
 
 - create a `<language>.ipynb` file that contains your graph post. This notebook will be parsed and rendered to a html site. Ideally, you provide both `fsharp.ipynb` and `csharp.ipynb`, but F#-only is okay as well. **do not forget to save the notebook with cell output**, as the notebook will not be executed on site generation.
+
+### update a post
+
+- Update an existing blog or graph gallery post in line with the instructions above.
+- Add metadata about the update to the `post_config.md` or `graph_post_config.md` according to this structure:
+    ```
+    last_updated_on: <YYYY-MM-DD>
+    last_updated_by: <your name>
+    last_updated_by_link: <a link>
+    ```
+    - `last_updated_on` is the date of the last update in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    - `last_updated_by` is an optional name of the contributing author
+    - `last_updated_by_link` is a optional link that will be associated with the contributing author name. Provide both `last_updated_by` and `last_updated_by_link` to display contributing author information. You can leave them out, for example, if you are updating your own post.

--- a/src/generators/layout.fsx
+++ b/src/generators/layout.fsx
@@ -163,7 +163,7 @@ let standardPostLayout (ctx: SiteContents) (post_config: Postloader.PostConfig) 
         post_config.date
         post_config.author
         post_config.author_link
-        post_config.last_updated_at
+        post_config.last_updated_on
         post_config.last_updated_by 
         post_config.last_updated_by_link
         toc
@@ -185,7 +185,7 @@ let graphGalleryPostLayout (ctx: SiteContents) (post_config: Graphgallerypostloa
         post_config.date
         post_config.author
         post_config.author_link
-        post_config.last_updated_at
+        post_config.last_updated_on
         post_config.last_updated_by 
         post_config.last_updated_by_link
         toc
@@ -242,7 +242,7 @@ let standardPostPreview (post: Postloader.NotebookPost) =
         post.post_config.date
         post.post_config.author
         post.post_config.author_link
-        post.post_config.last_updated_at
+        post.post_config.last_updated_on
         []
 
 let graphGalleryPostPreview (post: GraphGalleryPost) =
@@ -256,7 +256,7 @@ let graphGalleryPostPreview (post: GraphGalleryPost) =
         post.post_config.date
         post.post_config.author
         post.post_config.author_link
-        post.post_config.last_updated_at
+        post.post_config.last_updated_on
         (post.file_names |> Array.toList |> List.map (fun (lang, path) -> lang, Globals.prefixUrl $"graph-gallery/{path}"))
 
 let render (ctx : SiteContents) cnt =

--- a/src/generators/layout.fsx
+++ b/src/generators/layout.fsx
@@ -126,18 +126,15 @@ let postLayout (ctx : SiteContents) (metadata: SiteMetadata) (post_category:stri
 
                                             match post_updated_at with 
                                             | Some update_date ->
-                                                !! $"Last updated on {update_date.Year}-{update_date.Month}-{update_date.Day} "
+                                                h4 [Class "substitle is-white is-block"] [
+                                                    !! $"Last updated on {update_date.Year}-{update_date.Month}-{update_date.Day} "
+                                                    match post_updated_by, post_updated_by_link with 
+                                                    | (Some updated_author), (Some updated_author_link) -> 
+                                                        !! $"by "
+                                                        a [ Href updated_author_link; Class "is-aquamarine" ] [ !!updated_author ]
+                                                    | _, _ -> ()
+                                                ]
                                             | None -> ()
-
-                                            //     match post_updated_by with
-                                            //     | Some update_author ->
-                                            //         !! "by "
-
-                                            //         match post_updated_by_link with
-                                            //         | Some update_author_link ->
-                                            //             a [ Href update_author_link; Class "is-aquamarine" ] [ !!update_author_link ]
-                                            //         | None -> !! $"{update_author}"
-                                            //     | None -> () 
                                         ]
                                     ]
                                     yield! heroCnt
@@ -196,10 +193,9 @@ let graphGalleryPostLayout (ctx: SiteContents) (post_config: Graphgallerypostloa
         heroCnt
         bodyCnt
 
-let postPreview (preview_image_url: string option) (post_summary: string option) (post_url:string) (post_category_url:string) (post_category:string) (post_title:string) (post_date: System.DateTime) (post_author: string) (post_author_link: string) (post_updated_at: System.DateTime option) (post_updated_by: string option) (post_updated_by_link: string option) (tags:(string*string) list) =
+let postPreview (preview_image_url: string option) (post_summary: string option) (post_url:string) (post_category_url:string) (post_category:string) (post_title:string) (post_date: System.DateTime) (post_author: string) (post_author_link: string) (post_updated_at: System.DateTime option) (tags:(string*string) list) =
     let has_image = Option.isSome preview_image_url
     let has_summary = Option.isSome post_summary
-    let has_update = Option.isSome post_updated_at
 
     div [Class "card pt-2"] [ 
         if has_image then 
@@ -227,18 +223,10 @@ let postPreview (preview_image_url: string option) (post_summary: string option)
             !! "in "
             a [Href post_category_url; Class "is-aquamarine"] [!! (post_category)]
 
-            if has_update then
-                !! $"Last updated on {post_updated_at.Value.Year}-{post_updated_at.Value.Month}-{post_updated_at.Value.Day}"
-
-            //     match post_updated_by with
-            //     | Some update_author ->
-            //         !! "by "
-
-            //         match post_updated_by_link with
-            //         | Some update_author_link ->
-            //             a [ Href update_author_link; Class "is-aquamarine" ] [ !!update_author_link ]
-            //         | None -> !! $"{update_author}"
-            //     | None -> () 
+            match post_updated_at with 
+            | Some updated_date -> 
+                div [Class "content"] [!! $"Updated on {updated_date.Year}-{updated_date.Month}-{updated_date.Day}"]
+            | None -> ()
         ]
     ]
 
@@ -255,8 +243,6 @@ let standardPostPreview (post: Postloader.NotebookPost) =
         post.post_config.author
         post.post_config.author_link
         post.post_config.last_updated_at
-        post.post_config.last_updated_by
-        post.post_config.last_updated_by_link
         []
 
 let graphGalleryPostPreview (post: GraphGalleryPost) =
@@ -271,8 +257,6 @@ let graphGalleryPostPreview (post: GraphGalleryPost) =
         post.post_config.author
         post.post_config.author_link
         post.post_config.last_updated_at
-        post.post_config.last_updated_by
-        post.post_config.last_updated_by_link
         (post.file_names |> Array.toList |> List.map (fun (lang, path) -> lang, Globals.prefixUrl $"graph-gallery/{path}"))
 
 let render (ctx : SiteContents) cnt =

--- a/src/generators/layout.fsx
+++ b/src/generators/layout.fsx
@@ -65,7 +65,7 @@ let layout (ctx : SiteContents) (metadata: SiteMetadata) active bodyCnt =
         Components.Footer()
     ]
 
-let postLayout (ctx : SiteContents) (metadata: SiteMetadata) (post_category:string) (post_category_url:string) (post_title:string) (post_date:System.DateTime) (post_author:string) (post_author_link: string) (toc:HtmlElement) active heroCnt bodyCnt =
+let postLayout (ctx : SiteContents) (metadata: SiteMetadata) (post_category:string) (post_category_url:string) (post_title:string) (post_date:System.DateTime) (post_author:string) (post_author_link: string) (post_updated_at: System.DateTime option) (post_updated_by: string option) (post_updated_by_link: string option) (toc:HtmlElement) active heroCnt bodyCnt =
     let pages = ctx.TryGetValues<Pageloader.Page> () |> Option.defaultValue Seq.empty
     
     let ttl = metadata.Title
@@ -123,6 +123,21 @@ let postLayout (ctx : SiteContents) (metadata: SiteMetadata) (post_category:stri
                                             a [Href post_author_link; Class "is-aquamarine"] [!! post_author]
                                             !! $" in "
                                             a [Href post_category_url; Class "is-aquamarine"] [!! (post_category)]
+
+                                            match post_updated_at with 
+                                            | Some update_date ->
+                                                !! $"Last updated on {update_date.Year}-{update_date.Month}-{update_date.Day} "
+                                            | None -> ()
+
+                                            //     match post_updated_by with
+                                            //     | Some update_author ->
+                                            //         !! "by "
+
+                                            //         match post_updated_by_link with
+                                            //         | Some update_author_link ->
+                                            //             a [ Href update_author_link; Class "is-aquamarine" ] [ !!update_author_link ]
+                                            //         | None -> !! $"{update_author}"
+                                            //     | None -> () 
                                         ]
                                     ]
                                     yield! heroCnt
@@ -151,6 +166,9 @@ let standardPostLayout (ctx: SiteContents) (post_config: Postloader.PostConfig) 
         post_config.date
         post_config.author
         post_config.author_link
+        post_config.last_updated_at
+        post_config.last_updated_by 
+        post_config.last_updated_by_link
         toc
         active
         []
@@ -170,15 +188,18 @@ let graphGalleryPostLayout (ctx: SiteContents) (post_config: Graphgallerypostloa
         post_config.date
         post_config.author
         post_config.author_link
+        post_config.last_updated_at
+        post_config.last_updated_by 
+        post_config.last_updated_by_link
         toc
         active
         heroCnt
         bodyCnt
 
-let postPreview (preview_image_url: string option) (post_summary: string option) (post_url:string) (post_category_url:string) (post_category:string) (post_title:string) (post_date: System.DateTime) (post_author: string) (post_author_link: string) (tags:(string*string) list) =
-
+let postPreview (preview_image_url: string option) (post_summary: string option) (post_url:string) (post_category_url:string) (post_category:string) (post_title:string) (post_date: System.DateTime) (post_author: string) (post_author_link: string) (post_updated_at: System.DateTime option) (post_updated_by: string option) (post_updated_by_link: string option) (tags:(string*string) list) =
     let has_image = Option.isSome preview_image_url
     let has_summary = Option.isSome post_summary
+    let has_update = Option.isSome post_updated_at
 
     div [Class "card pt-2"] [ 
         if has_image then 
@@ -205,6 +226,19 @@ let postPreview (preview_image_url: string option) (post_summary: string option)
             a [Href post_author_link; Class "is-aquamarine"] [!! post_author]
             !! "in "
             a [Href post_category_url; Class "is-aquamarine"] [!! (post_category)]
+
+            if has_update then
+                !! $"Last updated on {post_updated_at.Value.Year}-{post_updated_at.Value.Month}-{post_updated_at.Value.Day}"
+
+            //     match post_updated_by with
+            //     | Some update_author ->
+            //         !! "by "
+
+            //         match post_updated_by_link with
+            //         | Some update_author_link ->
+            //             a [ Href update_author_link; Class "is-aquamarine" ] [ !!update_author_link ]
+            //         | None -> !! $"{update_author}"
+            //     | None -> () 
         ]
     ]
 
@@ -220,6 +254,9 @@ let standardPostPreview (post: Postloader.NotebookPost) =
         post.post_config.date
         post.post_config.author
         post.post_config.author_link
+        post.post_config.last_updated_at
+        post.post_config.last_updated_by
+        post.post_config.last_updated_by_link
         []
 
 let graphGalleryPostPreview (post: GraphGalleryPost) =
@@ -233,6 +270,9 @@ let graphGalleryPostPreview (post: GraphGalleryPost) =
         post.post_config.date
         post.post_config.author
         post.post_config.author_link
+        post.post_config.last_updated_at
+        post.post_config.last_updated_by
+        post.post_config.last_updated_by_link
         (post.file_names |> Array.toList |> List.map (fun (lang, path) -> lang, Globals.prefixUrl $"graph-gallery/{path}"))
 
 let render (ctx : SiteContents) cnt =

--- a/src/loaders/graphgallerypostloader.fsx
+++ b/src/loaders/graphgallerypostloader.fsx
@@ -51,8 +51,11 @@ type GraphGalleryPostConfig = {
     date: System.DateTime
     preview_image: string option
     summary: string option
+    last_updated_at: System.DateTime option
+    last_updated_by: string option
+    last_updated_by_link: string option
 } with
-    static member create(title, author, author_link, category, date, ?preview_image, ?summary) =
+    static member create(title, author, author_link, category, date, ?preview_image, ?summary, ?last_updated_at, ?last_updated_by, ?last_updated_by_link) =
         {
             title = title
             author = author
@@ -61,10 +64,18 @@ type GraphGalleryPostConfig = {
             date = date
             preview_image = preview_image
             summary = summary
+            last_updated_at = last_updated_at
+            last_updated_by = last_updated_by
+            last_updated_by_link = last_updated_by_link
         }
     static member ofMap (source:string) (m:Map<string,string>) =
 
         let mandatoryFieldMissing (fieldName: string) (source:string) (o:string Option) = if o.IsNone then failwith $"missing field '{fieldName}' in config from {source}" else o.Value
+        let parseDateString(dateString: string) = 
+            try 
+                System.DateTime.ParseExact(dateString,"yyyy-MM-dd",System.Globalization.CultureInfo.InvariantCulture)
+            with _ ->
+                failwith $"wrong date format in config from {source}, make sure to use YYY-MM-DD"
 
         let title = 
             m 
@@ -84,14 +95,14 @@ type GraphGalleryPostConfig = {
             with _ ->
                 failwith $"wrong post category format in config from {source}"
         let date = 
-            let tmp = m.TryFind "date" |> mandatoryFieldMissing "date" source
-            try 
-                System.DateTime.ParseExact(tmp,"yyyy-MM-dd",System.Globalization.CultureInfo.InvariantCulture)
-            with _ ->
-                failwith $"wrong date format in config from {source}, make sure to use YYY-MM-DD"
+            m.TryFind "date" |> mandatoryFieldMissing "date" source |> parseDateString
 
         let preview_image = m |> Map.tryFind "preview_image" 
         let summary = m |> Map.tryFind "summary" 
+
+        let last_updated_at = m.TryFind "last_updated_at" |> Option.map parseDateString
+        let last_updated_by = m.TryFind "last_updated_by"
+        let last_updated_by_link = m.TryFind "last_updated_by_link"        
 
         GraphGalleryPostConfig.create(
             title = title,
@@ -100,7 +111,10 @@ type GraphGalleryPostConfig = {
             category = category,
             date = date,
             ?preview_image = preview_image,
-            ?summary = summary
+            ?summary = summary,
+            ?last_updated_at = last_updated_at,
+            ?last_updated_by = last_updated_by,
+            ?last_updated_by_link = last_updated_by_link
         )
 
 type GraphGalleryPost = {

--- a/src/loaders/graphgallerypostloader.fsx
+++ b/src/loaders/graphgallerypostloader.fsx
@@ -51,11 +51,11 @@ type GraphGalleryPostConfig = {
     date: System.DateTime
     preview_image: string option
     summary: string option
-    last_updated_at: System.DateTime option
+    last_updated_on: System.DateTime option
     last_updated_by: string option
     last_updated_by_link: string option
 } with
-    static member create(title, author, author_link, category, date, ?preview_image, ?summary, ?last_updated_at, ?last_updated_by, ?last_updated_by_link) =
+    static member create(title, author, author_link, category, date, ?preview_image, ?summary, ?last_updated_on, ?last_updated_by, ?last_updated_by_link) =
         {
             title = title
             author = author
@@ -64,7 +64,7 @@ type GraphGalleryPostConfig = {
             date = date
             preview_image = preview_image
             summary = summary
-            last_updated_at = last_updated_at
+            last_updated_on = last_updated_on
             last_updated_by = last_updated_by
             last_updated_by_link = last_updated_by_link
         }
@@ -100,7 +100,7 @@ type GraphGalleryPostConfig = {
         let preview_image = m |> Map.tryFind "preview_image" 
         let summary = m |> Map.tryFind "summary" 
 
-        let last_updated_at = m.TryFind "last_updated_at" |> Option.map parseDateString
+        let last_updated_on = m.TryFind "last_updated_on" |> Option.map parseDateString
         let last_updated_by = m.TryFind "last_updated_by"
         let last_updated_by_link = m.TryFind "last_updated_by_link"        
 
@@ -112,7 +112,7 @@ type GraphGalleryPostConfig = {
             date = date,
             ?preview_image = preview_image,
             ?summary = summary,
-            ?last_updated_at = last_updated_at,
+            ?last_updated_on = last_updated_on,
             ?last_updated_by = last_updated_by,
             ?last_updated_by_link = last_updated_by_link
         )

--- a/src/loaders/postloader.fsx
+++ b/src/loaders/postloader.fsx
@@ -39,11 +39,11 @@ type PostConfig = {
     date: System.DateTime
     preview_image: string option
     summary: string option
-    last_updated_at: System.DateTime option
+    last_updated_on: System.DateTime option
     last_updated_by: string option
     last_updated_by_link: string option
 } with
-    static member create(title, author, author_link, category, date, ?preview_image, ?summary, ?last_updated_at, ?last_updated_by, ?last_updated_by_link) =
+    static member create(title, author, author_link, category, date, ?preview_image, ?summary, ?last_updated_on, ?last_updated_by, ?last_updated_by_link) =
         {
             title = title
             author = author
@@ -52,7 +52,7 @@ type PostConfig = {
             date = date
             preview_image = preview_image
             summary = summary
-            last_updated_at = last_updated_at
+            last_updated_on = last_updated_on
             last_updated_by = last_updated_by
             last_updated_by_link = last_updated_by_link
         }
@@ -88,7 +88,7 @@ type PostConfig = {
         let preview_image = m |> Map.tryFind "preview_image" 
         let summary = m |> Map.tryFind "summary" 
 
-        let last_updated_at = m.TryFind "last_updated_at" |> Option.map parseDateString
+        let last_updated_on = m.TryFind "last_updated_on" |> Option.map parseDateString
         let last_updated_by = m.TryFind "last_updated_by"
         let last_updated_by_link = m.TryFind "last_updated_by_link"
 
@@ -100,7 +100,7 @@ type PostConfig = {
             date = date,
             ?preview_image = preview_image,
             ?summary = summary,
-            ?last_updated_at = last_updated_at,
+            ?last_updated_on = last_updated_on,
             ?last_updated_by = last_updated_by,
             ?last_updated_by_link = last_updated_by_link
         )

--- a/src/loaders/postloader.fsx
+++ b/src/loaders/postloader.fsx
@@ -39,8 +39,11 @@ type PostConfig = {
     date: System.DateTime
     preview_image: string option
     summary: string option
+    last_updated_at: System.DateTime option
+    last_updated_by: string option
+    last_updated_by_link: string option
 } with
-    static member create(title, author, author_link, category, date, ?preview_image, ?summary) =
+    static member create(title, author, author_link, category, date, ?preview_image, ?summary, ?last_updated_at, ?last_updated_by, ?last_updated_by_link) =
         {
             title = title
             author = author
@@ -49,10 +52,18 @@ type PostConfig = {
             date = date
             preview_image = preview_image
             summary = summary
+            last_updated_at = last_updated_at
+            last_updated_by = last_updated_by
+            last_updated_by_link = last_updated_by_link
         }
     static member ofMap (source:string) (m:Map<string,string>) =
 
         let mandatoryFieldMissing (fieldName: string) (source:string) (o:string Option) = if o.IsNone then failwith $"missing field {fieldName} in config from {source}" else o.Value
+        let parseDateString(dateString: string) = 
+            try 
+                System.DateTime.ParseExact(dateString,"yyyy-MM-dd",System.Globalization.CultureInfo.InvariantCulture)
+            with _ ->
+                failwith $"wrong date format in config from {source}, make sure to use YYY-MM-DD"
 
         let title = 
             m 
@@ -72,14 +83,14 @@ type PostConfig = {
             with _ ->
                 failwith $"wrong post category format in config from {source}"
         let date = 
-            let tmp = m.TryFind "date" |> mandatoryFieldMissing "date" source
-            try 
-                System.DateTime.ParseExact(tmp,"yyyy-MM-dd",System.Globalization.CultureInfo.InvariantCulture)
-            with _ ->
-                failwith $"wrong date format in config from {source}, make sure to use YYY-MM-DD"
+            m.TryFind "date" |> mandatoryFieldMissing "date" source |> parseDateString
 
         let preview_image = m |> Map.tryFind "preview_image" 
         let summary = m |> Map.tryFind "summary" 
+
+        let last_updated_at = m.TryFind "last_updated_at" |> Option.map parseDateString
+        let last_updated_by = m.TryFind "last_updated_by"
+        let last_updated_by_link = m.TryFind "last_updated_by_link"
 
         PostConfig.create(
             title = title,
@@ -88,7 +99,10 @@ type PostConfig = {
             category = category,
             date = date,
             ?preview_image = preview_image,
-            ?summary = summary
+            ?summary = summary,
+            ?last_updated_at = last_updated_at,
+            ?last_updated_by = last_updated_by,
+            ?last_updated_by_link = last_updated_by_link
         )
 type NotebookPost = {
     file_name: string

--- a/src/posts/getting-started/post_config.md
+++ b/src/posts/getting-started/post_config.md
@@ -4,4 +4,7 @@ author: David Zimmer
 author_link: https://github.com/ZimmerD
 category: datascience
 date: 2021-02-09
+last_updated_on: 2023-09-30
+last_updated_by: Jay Goldstein
+last_updated_by_link: https://github.com/Janna112358
 ---


### PR DESCRIPTION
I updated the "getting started" post in PR #12 and I thought it would be nice to have a place in the post header and preview to display some information about the last update.

### Changes
- Added the fields "last_updated_on", "last_updated_by" and "last_updated_by_link" to the post config types as optional fields
- If "last_updated_on" is given, show this in the post preview as "Updated on <date>"
- If "last_updated_on" is given, show this in the post header as "Last updated on <date>". If "last_updated_by" and "last_updated_by_link" are also given, add "by <author name with link>" (similar to how the main author is shown). 
- Add instructions to the README on how to add this information in the config file in a new section on post updates
- Add my own info to the config file of the getting started post